### PR TITLE
ci: Add dependabot and project (classic) workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/assign-to-project-classic-main.yml
+++ b/.github/workflows/assign-to-project-classic-main.yml
@@ -1,0 +1,26 @@
+name: Assign to Project (classic) MAIN
+on:
+  issue_comment:
+    types: [ created ]
+  issues:
+    types: [ opened ]
+  pull_request:
+    types: [ opened ]
+  pull_request_target:
+    types: [ opened ]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  assign-project-main:
+    runs-on: ubuntu-latest
+    name: Assign to Project
+    steps:
+    - name: Assign new issues and new pull requests to project MAIN
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: |
+        github.event.action == 'created' ||
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened'
+      with:
+        project: 'https://github.com/tkuaiic/tkuaiic-discord-bot-python/projects/1'
+        column_name: 'Backlog'


### PR DESCRIPTION
- dependabot
- assign-to-project-classic-main