### PR TITLE
feat: new `/eip` command with two features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ sftp-config.json
 
 # TKUAIIC bot install & usage
 credentials.json
+secret.py
 
 # Building & testing
 npm-debug.log

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,11 +6,9 @@ the bot "in-place", as long as you have the necessary prerequisites available.
 Required environment as of TKUAIIC Discord bot 1.0.0:
 
 * Device with Python 3 or higher, plus the following libraries and modules:
+  * discord-py-interactions
+  * interactions-persistence
   * firebase_admin
-  * interactions
-  * logging
-  * os
-* Firebase
 
 TKUAIIC Discord bot is developed and tested mainly on Unix/Linux platforms, but
 should work on Windows as well.

--- a/main.py
+++ b/main.py
@@ -149,7 +149,7 @@ async def callback(ctx, response: str):
     custom_id = interactions.ext.persistence.PersistentCustomID(
         bot,
         "leave_form",
-        event_selection
+        event_dict[event_selection], # Persistence extension will crash when encountering Chinese, [see here](https://discord.com/channels/789032594456576001/1037090379935256576/1037386313592229928)
     )
     modal = interactions.Modal(
         title=f"【{event_selection}】請假單",

--- a/main.py
+++ b/main.py
@@ -191,7 +191,7 @@ async def modal_response(ctx, event_type, leave_date: str, leave_type: str, leav
     if leave_date:
         leave_delta = (leave_date - dt.today().date()).days
         if leave_delta > 0: #確保不可在當天或逾期請假
-            channel = await get(bot, interactions.Channel, object_id=env.leave_channel)
+            channel = await get(bot, interactions.Channel, object_id=<leave_channel>) # Replace <leave_channel> with the actual announcement channel ID
             discord_id = f'{ctx.author.username}#{ctx.author.discriminator}'
             timestamp = dt.now().isoformat()
             leave_name = list(event_dict.keys())[list(event_dict.values()).index(event_type)]
@@ -337,7 +337,7 @@ async def modal_response(ctx, announcement_type, announcement_title: str, announ
             return
         else:
             role, = roles # Unpack from list
-    channel = await get(bot, interactions.Channel, object_id=<announcement_channel>) # Replace <announcement_channel> with the actual announcement channel ID
+    channel = await get(bot, interactions.Channel, object_id=1034812177703505973) # Replace <announcement_channel> with the actual announcement channel ID
     name = list(announcement_dict.keys())[list(announcement_dict.values()).index(announcement_type)]
     msg = f"【{name}】\n" +\
         f"標題：{announcement_title}\n" +\

--- a/main.py
+++ b/main.py
@@ -198,7 +198,7 @@ async def modal_response(ctx, event_type, leave_date: str, leave_type: str, leav
             # logging.info(f"Leave =>")
             embeds=interactions.Embed(title=f"【{leave_name}】請假單", color=0x00bfff)
             embeds.set_author(name=f"{id_to_name(discord_id, '1111-cadre')}", icon_url=f"{ctx.author.avatar_url}?size=1024")
-            embeds.set_thumbnail(url="https://i.ibb.co/6BK3PR9/image.png")
+            embeds.set_thumbnail(url="https://media.discordapp.net/attachments/1031820876032782346/1056797437676769330/3e5d8d13beec7333.png")
             embeds.add_field(name="假別", value=f"{leave_type}\a\a\a\a", inline=True)
             embeds.add_field(name="時間", value=f"{leave_date}", inline=True)
             embeds.add_field(name="請假原因", value=f"{leave_reason}", inline=False)

--- a/main.py
+++ b/main.py
@@ -3,9 +3,11 @@ from firebase_admin import credentials, firestore
 from datetime import datetime as dt
 
 # These are basic inits for discord bot to function corrrectly
+import secret
+env = secret.test
 bot = interactions.Client(
-    token = os.getenv("DISCORD_TOKEN"),
-    default_scope = os.getenv("DISCORD_SCOPE"),
+    token = env.token,
+    default_scope = env.scope,
 )
 bot.load("interactions.ext.persistence")
 from interactions.ext.persistence import keygen
@@ -191,7 +193,7 @@ async def modal_response(ctx, event_type, leave_date: str, leave_type: str, leav
     if leave_date:
         leave_delta = (leave_date - dt.today().date()).days
         if leave_delta > 0: #確保不可在當天或逾期請假
-            channel = await get(bot, interactions.Channel, object_id=<leave_channel>) # Replace <leave_channel> with the actual announcement channel ID
+            channel = await get(bot, interactions.Channel, object_id=env.leave_channel)
             discord_id = f'{ctx.author.username}#{ctx.author.discriminator}'
             timestamp = dt.now().isoformat()
             leave_name = list(event_dict.keys())[list(event_dict.values()).index(event_type)]
@@ -337,7 +339,7 @@ async def modal_response(ctx, announcement_type, announcement_title: str, announ
             return
         else:
             role, = roles # Unpack from list
-    channel = await get(bot, interactions.Channel, object_id=1034812177703505973) # Replace <announcement_channel> with the actual announcement channel ID
+    channel = await get(bot, interactions.Channel, object_id=env.announcement_channel)
     name = list(announcement_dict.keys())[list(announcement_dict.values()).index(announcement_type)]
     msg = f"【{name}】\n" +\
         f"標題：{announcement_title}\n" +\


### PR DESCRIPTION
Two features(subcommands):
1. `leave`: Allow cadres to submit a leave application, generates a ticket and logs it into database automatically
2. `announcement`: Allow cadres to make an announcement, main purpose is to prevent cadres from chatting accidently inside the announcement channel as well as unifying the announcement format